### PR TITLE
Multigpu support

### DIFF
--- a/train_adaptive.py
+++ b/train_adaptive.py
@@ -211,11 +211,11 @@ is_compression_reached = False
 
 
 # eval every steps before train
-#if not args.debug:
-#    model = model.eval()
-#    harness_metrics = eval_utils.evaluate_with_harness(model, tokenizer, device=model.device, debug=args.debug, batch_size=args.batch_size)
-#    wandb.log({**harness_metrics, 'step': 0})
-#    model = model.train()
+if not args.debug:
+    model = model.eval()
+    harness_metrics = eval_utils.evaluate_with_harness(model, tokenizer, device=model.device, debug=args.debug, batch_size=args.batch_size)
+    wandb.log({**harness_metrics, 'step': 0})
+    model = model.train()
 
 # flag, do one eval at 5% compression
 eval_at_95 = True

--- a/train_adaptive.py
+++ b/train_adaptive.py
@@ -266,7 +266,6 @@ for epoch in range(args.epochs):
             # adaptive_rank_selection.freeze_model_masks(model, should_freeze=True)
 
             metrics = adaptive_rank_selection.eval_model(model, test_dl, tokenizer.pad_token_id, args, compression_calculator)
-            model = model.cuda() 
             harness_metrics = eval_utils.evaluate_with_harness(model, tokenizer, device=model.device, debug=args.debug, batch_size=args.eval_batch_size)
         
             wandb.log({**metrics, **harness_metrics, 'step': global_step})

--- a/utils/adaptive_rank_selection.py
+++ b/utils/adaptive_rank_selection.py
@@ -131,6 +131,10 @@ class LowrankLinear(torch.nn.Module):
         if self.training:
             self.E_train_mask = E_train_mask 
         inputs = inputs.transpose(1, 2)
+
+        if inputs.device != self.V_t.device: # multi-gpu setup
+            inputs = inputs.to(self.V_t.device)
+
         output = (self.UE * E_train_mask.unsqueeze(0)) @ (self.V_t @ inputs)
         output = output.transpose(1, 2)
 
@@ -253,6 +257,10 @@ class LowrankLinearSimple(torch.nn.Module):
         E_train_mask = self.calculate_mask(is_training=self.training)
         if self.training:
             self.E_train_mask = E_train_mask
+
+        if inputs.device != self.V_t.device: # multi-gpu setup
+            inputs = inputs.to(self.V_t.device)
+        
         inputs = inputs.transpose(1, 2)
         output = (self.UE * E_train_mask.unsqueeze(0)) @ (self.V_t @ inputs)
         output = output.transpose(1, 2)
@@ -275,7 +283,7 @@ class LowrankLinearSimple(torch.nn.Module):
         if is_training or self.E_train_mask is None:
             logit_mask = self.E_train
             E_train_mask = gumbel_sigmoid(logit_mask, tau=self.tau)
-            #self.E_train_mask = STE.apply(self.E_train_mask)
+            # self.E_train_mask = STE.apply(self.E_train_mask)
         else:
             E_train_mask = self.E_train_mask
 

--- a/utils/adaptive_rank_selection.py
+++ b/utils/adaptive_rank_selection.py
@@ -134,7 +134,8 @@ class LowrankLinear(torch.nn.Module):
 
         if inputs.device != self.V_t.device: # multi-gpu setup
             inputs = inputs.to(self.V_t.device)
-
+        if E_train_mask != self.V_t.device:
+            E_train_mask = E_train_mask.to(self.V_t.device)
         output = (self.UE * E_train_mask.unsqueeze(0)) @ (self.V_t @ inputs)
         output = output.transpose(1, 2)
 

--- a/utils/adaptive_rank_selection.py
+++ b/utils/adaptive_rank_selection.py
@@ -314,7 +314,11 @@ def calculate_r_align(compression_calculator):
             #m[:k] = 1.
         
         E = module.E.to(module.E_train_mask.dtype).to(module.E_train_mask.device)
-        loss += F.mse_loss(module.E_train_mask * E, m * E, reduction='mean')
+
+        if isinstance(loss, torch.Tensor): 
+            loss += F.mse_loss(module.E_train_mask * E, m * E, reduction='mean').to(loss.device)
+        else:
+            loss += F.mse_loss(module.E_train_mask * E, m * E, reduction='mean')
 
     loss = loss/len(compression_calculator.lowrank_layers)
     return loss

--- a/utils/adaptive_rank_selection.py
+++ b/utils/adaptive_rank_selection.py
@@ -284,7 +284,7 @@ class LowrankLinearSimple(torch.nn.Module):
         if is_training or self.E_train_mask is None:
             logit_mask = self.E_train
             E_train_mask = gumbel_sigmoid(logit_mask, tau=self.tau)
-            # self.E_train_mask = STE.apply(self.E_train_mask)
+            E_train_mask = STE.apply(E_train_mask)
         else:
             E_train_mask = self.E_train_mask
 

--- a/utils/lowrank_modeling.py
+++ b/utils/lowrank_modeling.py
@@ -168,7 +168,7 @@ class CompressionCalculator:
     def get_sv_ratio(self):
         keep_ratio = 0. 
         for module in self.lowrank_layers:
-            keep_ratio += module.calculate_mask(is_training=True).mean()
+            keep_ratio += module.calculate_mask(is_training=True).mean().item()
 
         return keep_ratio/len(self.lowrank_layers)
 

--- a/utils/train_utils.py
+++ b/utils/train_utils.py
@@ -1,5 +1,6 @@
 import torch.nn.functional as F
 from tqdm import tqdm
+import torch
 
 def configure_required_grad(model):
     """
@@ -38,3 +39,27 @@ def count_parameters(model):
     total_params = sum(p.numel() for p in model.parameters())
     total_params_in_billion = total_params / 1e9
     return total_params_in_billion
+
+def push_to_multi_gpu(model):
+    """
+    Pushes MLP layers with numbers between 3 and 20 in their names to one GPU (device 1),
+    and the rest of the layers to another GPU (device 0).
+    """
+
+    if torch.cuda.is_available() and torch.cuda.device_count() >= 2:
+        device0 = torch.device("cuda:0")
+        device1 = torch.device("cuda:1")
+    else:
+        raise RuntimeError("At least two CUDA devices are required for this operation.")
+
+    # Push modules to the corresponding devices
+    for name, module in model.named_modules():
+        # Check if 'mlp' is in the name and if any number between 3 and 20 is present
+        if  'gate_proj' in name or 'up_proj' in name:
+            module.to(device1)  # Push to device 1
+            print(f"{name} pushed to device 1 (cuda:1)")
+        else:
+            module.to(device0)  # Push to device 0
+            print(f"{name} pushed to device 0 (cuda:0)")
+
+    return model


### PR DESCRIPTION
Adds support for #2 

```
NUM_TRAIN_SAMPLES=50000
MAX_LEN=256
BETA=1.
ACT_AWARE=activation
COMP_VALUES=(0.90 0.85 0.80)
EVAL_BS=8
BATCH_SIZE=2
LTYPE=adaptive
R_LOSS=default
LR=1e-3

MODEL=meta-llama/Llama-2-13b-hf
CACHE_DIR=/exports/eddie/scratch/s2593541/lrd/cache_train_llama13
LAMBDA=16.
GAMMA=1.

# Loop over the COMP values
for i in ${!COMP_VALUES[@]}; do
    COMP=${COMP_VALUES[$i]}
    EXP_NAME="${MODEL#*/}_${LTYPE}_${COMP}_fixmse_${GAMMA}_${LAMBDA}"
    p_param=0.4
    # Check if it's the first iteration
    if [ $i -eq 0 ]; then
        # Command for the first iteration without extra arguments
        python train_adaptive.py --model=$MODEL --target_param_ratio=$COMP --eval_full --batch_size=$BATCH_SIZE --lr=$LR --num_train_samples=$NUM_TRAIN_SAMPLES --exp_name=$EXP_NAME --max_length=$MAX_LEN --cache_dir=$CACHE_DIR --eval_freq_steps=500 --eval_batch_size=$EVAL_BS --alpha=0.5 --lambda=$LAMBDA --gamma=$GAMMA --act_aware=$ACT_AWARE  --layer_type=$LTYPE --beta_scale=$BETA --r_loss=$R_LOSS --tau=0.4 --p_param=$p_param --load_act_cache
    else
        python train_adaptive.py --model=$MODEL --target_param_ratio=$COMP --eval_full --batch_size=$BATCH_SIZE --lr=$LR --num_train_samples=$NUM_TRAIN_SAMPLES --exp_name=$EXP_NAME --max_length=$MAX_LEN --cache_dir=$CACHE_DIR --eval_freq_steps=500 --eval_batch_size=$EVAL_BS --alpha=0.5 --lambda=$LAMBDA --gamma=$GAMMA --act_aware=$ACT_AWARE --load_act_cache --layer_type=$LTYPE --beta_scale=$BETA --r_loss=$R_LOSS
    fi
done
```